### PR TITLE
[손진아] w6_리뷰요청_친구

### DIFF
--- a/back-end/friend.resolver.js
+++ b/back-end/friend.resolver.js
@@ -1,0 +1,177 @@
+const Sequelize = require('sequelize');
+
+const { Op } = Sequelize;
+const { getPageResult, getEdgesFromNodes } = require('../../util/graphql/cursor');
+
+const friendResolvers = {
+  Query: {
+    friends: async (obj, { first, after }, { Friends, Users, req }) => {
+      const afterClause = after
+        ? {
+            id: {
+              [Op.gt]: after,
+            },
+          }
+        : {};
+      const nodes = await Friends.findAll({
+        where: {
+          [Op.and]: [
+            {
+              pFriendId: req.user.id,
+            },
+            afterClause,
+          ],
+        },
+        include: [
+          {
+            model: Users,
+            as: 'sFriend',
+          },
+        ],
+        limit: first,
+        order: [['id']],
+      });
+
+      const edges = getEdgesFromNodes(nodes, (node) => node.id);
+      return getPageResult(edges, first);
+    },
+    addFriendForTest: async (obj, args, { Friends }) => {
+      try {
+        await Friends.create({ pFriendId: 4, sFriendId: 22 });
+        await Friends.create({ pFriendId: 22, sFriendId: 4 });
+      } catch {
+        console.log('already exists');
+      }
+      return Friends.findAll({
+        where: {
+          [Op.or]: [
+            { [Op.and]: [{ pFriendId: 1 }, { sFriendId: 2 }] },
+            { [Op.and]: [{ pFriendId: 2 }, { sFriendId: 1 }] },
+          ],
+        },
+      });
+    },
+  },
+  Mutation: {
+    findFriendRequests: async (obj, args, { BeforeFriends, Users, req }) => {
+      const sFriendRows = await BeforeFriends.findAll({
+        where: { [Op.and]: [{ sFriendId: req.user.id }, { friendStateId: 1 }] },
+      });
+      return Users.findAll({
+        where: { id: sFriendRows.map((acc) => acc.dataValues.pFriendId) },
+      });
+    },
+    deleteFriend: async (obj, { nickname }, { Friends, Users, req, sequelize }) => {
+      const deletedColumns = await Friends.findAll({
+        include: [
+          {
+            model: Users,
+            as: 'sFriend',
+            where: { [Op.or]: [{ nickname: nickname }, { id: req.user.id }] },
+          },
+          {
+            model: Users,
+            as: 'pFriend',
+            where: { [Op.or]: [{ nickname: nickname }, { id: req.user.id }] },
+          },
+        ],
+      });
+
+      let transaction;
+      try {
+        transaction = await sequelize.transaction();
+        await Friends.destroy({ where: { id: deletedColumns[0].dataValues.id }, transaction });
+        await Friends.destroy({ where: { id: deletedColumns[1].dataValues.id }, transaction });
+        await transaction.commit();
+        return {
+          nickname: nickname,
+        };
+      } catch (e) {
+        if (transaction) await transaction.rollback();
+        throw new Error(e);
+      }
+    },
+    deleteFriendRequest: async (obj, { nickname }, { BeforeFriends, Users, req }) => {
+      const idFromNickname = await Users.findOne({
+        where: { nickname: nickname },
+      });
+      const conditionColumns = {
+        where: {
+          [Op.and]: [{ pFriendId: idFromNickname.dataValues.id }, { sFriendId: req.user.id }],
+        },
+      };
+      await BeforeFriends.destroy(conditionColumns);
+      return BeforeFriends.findAll(conditionColumns);
+    },
+    acceptFriendRequest: async (obj, { nickname }, { Users, Friends, req }) => {
+      const idFromNickname = await Users.findOne({
+        where: { nickname: nickname },
+      });
+      try {
+        await Friends.create({
+          pFriendId: idFromNickname.dataValues.id,
+          sFriendId: req.user.id,
+        });
+        await Friends.create({
+          pFriendId: req.user.id,
+          sFriendId: idFromNickname.dataValues.id,
+        });
+      } catch {
+        console.log('already exists');
+      }
+      await Friends.update(
+        { friendStateId: 2 },
+        {
+          where: {
+            [Op.and]: [{ pFriendId: idFromNickname.dataValues.id }, { sFriendId: req.user.id }],
+          },
+        },
+      );
+      return {
+        user: idFromNickname,
+        result: true,
+      };
+    },
+
+    sendFriendRequest: async (obj, { nickname }, { Friends, BeforeFriends, Users, req }) => {
+      // 이미 친구인지 확인
+      const checkFriendsTable = await Friends.findAll({
+        include: [
+          {
+            model: Users,
+            as: 'sFriend',
+            where: { [Op.or]: [{ nickname: nickname }, { id: req.user.id }] },
+          },
+          {
+            model: Users,
+            as: 'pFriend',
+            where: { [Op.or]: [{ nickname: nickname }, { id: req.user.id }] },
+          },
+        ],
+      });
+
+      if (checkFriendsTable.length > 1) throw new Error(`${nickname}님과는 이미 친구입니다.`);
+
+      // 친구 요청
+      const idFromNickname = await Users.findOne({
+        where: { nickname: nickname },
+      });
+
+      try {
+        await BeforeFriends.create({
+          pFriendId: req.user.id,
+          sFriendId: idFromNickname.dataValues.id,
+          friendStateId: 1,
+        });
+      } catch (e) {
+        if (e.message === 'Validation error') {
+          throw new Error(`이미 친구 신청을 보냈습니다.`);
+        }
+        throw new Error(`${nickname}님은 유저가 아닙니다.`);
+      }
+      return { nickname: nickname };
+    },
+  },
+};
+
+module.exports = friendResolvers;

--- a/back-end/friend.typeDef.js
+++ b/back-end/friend.typeDef.js
@@ -1,0 +1,43 @@
+module.exports = `
+  type Friend{
+    id:Int!
+    pFriend:User
+    sFriend:User
+    createdAt:String
+    updatedAt:String
+  }
+
+  type BeforeFriend{
+    id:Int!
+    pFriendId:Int!
+    sFriendId:Int!
+    friendStateid:Int!
+  }
+  
+  type FriendEdge{
+    node:Friend
+    cursor:String
+  }
+  
+  type FriendConnection{
+    edges:[FriendEdge]
+    pageInfo:PageInfo
+  }
+  
+  type FriendResult{
+    nickname: String
+  }
+  
+  extend type Query{
+    friends(first:Int!,after:String):FriendConnection
+    addFriendForTest:[Friend]
+  } 
+
+  extend type Mutation{
+    deleteFriend(nickname:String):FriendResult
+    findFriendRequests:[User]
+    deleteFriendRequest(nickname:String):[BeforeFriend]
+    acceptFriendRequest(nickname:String):FriendResult
+    sendFriendRequest(nickname:String):FriendResult
+  }
+`;

--- a/front-end/FriendsSection/FriendList/Component/Component.js
+++ b/front-end/FriendsSection/FriendList/Component/Component.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { faMinusCircle, faCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+  ComponentStyle,
+  CircleStyle,
+  Icon,
+} from 'components/FriendsSection/refactor/FriendList/Component/Component.style';
+import PropTypes from 'prop-types';
+
+Component.propTypes = {
+  nickname: PropTypes.string,
+  online: PropTypes.bool,
+  isConfigMode: PropTypes.bool,
+  dispatchModalContent: PropTypes.func,
+};
+
+Component.defaultProps = {
+  nickname: null,
+  online: false,
+  isConfigMode: false,
+  dispatchModalContent: null,
+};
+
+export default function Component({
+  nickname,
+  online,
+  isConfigMode,
+  dispatchModalContent,
+}) {
+  function clickDeleteButton() {
+    dispatchModalContent({ type: 'deleteRequest', nickname });
+  }
+
+  return (
+    <ComponentStyle>
+      <span>{nickname}</span>
+      <CircleStyle icon={faCircle} online={online} />
+      {isConfigMode ? (
+        <Icon icon={faMinusCircle} onClick={clickDeleteButton} />
+      ) : null}
+    </ComponentStyle>
+  );
+}

--- a/front-end/FriendsSection/FriendList/Component/Component.style.js
+++ b/front-end/FriendsSection/FriendList/Component/Component.style.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export const ComponentStyle = styled.div`
+  display: flex;
+  width: 7rem;
+  height: 1rem;
+  padding-top: 0.5rem;
+  padding-left: 1rem;
+  padding-bottom: 1rem;
+  font-size: 17px;
+  align-items: center;
+
+  > span {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  > *:first-child {
+    flex: 1;
+  }
+`;
+
+export const Icon = styled(FontAwesomeIcon).attrs({
+  size: 'lg',
+})`
+  margin-left: auto;
+  margin-right: 0;
+  cursor: pointer;
+`;
+
+export const CircleStyle = styled(FontAwesomeIcon).attrs({
+  size: '1x',
+})`
+  margin-right: 0.3rem;
+  color: ${(props) => (props.online ? props.theme.eastSide : '#606060')};
+`;

--- a/front-end/FriendsSection/FriendList/FriendList.js
+++ b/front-end/FriendsSection/FriendList/FriendList.js
@@ -1,0 +1,78 @@
+import React, { useReducer } from 'react';
+import Header from 'components/FriendsSection/refactor/FriendList/Header/Header';
+import Component from 'components/FriendsSection/refactor/FriendList/Component/Component';
+import Alert from 'components/globalComponents/Alert/Alert';
+import {
+  FriendListStyle,
+  Div,
+} from 'components/FriendsSection/refactor/FriendList/FriendList.style';
+import { GET_FRIENDS } from 'queries/friend';
+import useCursorQuery from 'hooks/useCursorQuery';
+import InfinityScroll from 'components/globalComponents/InfinityScroll/InfinityScroll';
+import FriendModal from 'components/FriendsSection/refactor/FriendList/FriendModal/FriendModal';
+import modalReducer from 'components/FriendsSection/refactor/FriendList/modalReducer';
+
+function changeModeReducer(state, action) {
+  return !action.current;
+}
+
+export default function FriendList() {
+  const [isConfigMode, changeMode] = useReducer(changeModeReducer, false);
+  const { data, loading, error, fetchMore, hasMore, refetch } = useCursorQuery(
+    GET_FRIENDS,
+  );
+  const [modalContent, dispatchModalContent] = useReducer(modalReducer, {
+    content: null,
+    nickname: null,
+    current: null,
+  });
+
+  if (loading) {
+    return (
+      <FriendListStyle>
+        <Header />
+      </FriendListStyle>
+    );
+  }
+  if (error) {
+    return (
+      <FriendListStyle>
+        <Header />
+        <Alert type="error" />
+      </FriendListStyle>
+    );
+  }
+
+  function switchMode() {
+    changeMode({ current: isConfigMode });
+  }
+  return (
+    <>
+      <FriendModal
+        modalContent={modalContent}
+        dispatchModalContent={dispatchModalContent}
+        refetch={refetch}
+      />
+      <FriendListStyle>
+        <Header
+          isConfigMode={isConfigMode}
+          switchMode={switchMode}
+          dispatchModalContent={dispatchModalContent}
+        />
+        <InfinityScroll loadMore={fetchMore} hasMore={hasMore}>
+          <Div>
+            {data.map(({ sFriend: { nickname } }) => (
+              <Component
+                key={nickname}
+                nickname={nickname}
+                online={false}
+                isConfigMode={isConfigMode}
+                dispatchModalContent={dispatchModalContent}
+              />
+            ))}
+          </Div>
+        </InfinityScroll>
+      </FriendListStyle>
+    </>
+  );
+}

--- a/front-end/FriendsSection/FriendList/FriendList.style.js
+++ b/front-end/FriendsSection/FriendList/FriendList.style.js
@@ -1,0 +1,38 @@
+import styled, { keyframes } from 'styled-components';
+
+const friendsBtnBottom = 3;
+const friendsBtnRight = 2;
+const slideUp = keyframes`
+    0% {
+      opacity: 0;
+      transform: translateY(1.6rem);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+`;
+
+export const FriendListStyle = styled.div`
+  animation: ${slideUp} 0.15s ease 1;
+  position: fixed;
+  bottom: ${friendsBtnBottom + 5}rem;
+  right: ${friendsBtnRight}rem;
+  width: 9rem;
+  height: auto;
+  background-color: ${(props) => props.theme.pink};
+`;
+
+export const Div = styled.div`
+  max-height: 20rem;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  &::-webkit-scrollbar {
+    width: 9px;
+    background: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${(props) => props.theme.darkPink};
+    opacity: 0.4;
+  }
+`;

--- a/front-end/FriendsSection/FriendList/FriendModal/FriendModal.js
+++ b/front-end/FriendsSection/FriendList/FriendModal/FriendModal.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import makeModal from 'components/globalComponents/Modal/Modal';
+import Button from 'components/globalComponents/Button/Button';
+import { ButtonSection } from 'components/FriendsSection/refactor/FriendList/FriendModal/FriendModal.style';
+import PropTypes from 'prop-types';
+import { DELETE_FRIEND, SEND_FRIEND_REQUEST } from 'queries/friend';
+import { useMutation } from '@apollo/react-hooks';
+
+FriendModal.propTypes = {
+  modalContent: PropTypes.objectOf(PropTypes.string),
+  dispatchModalContent: PropTypes.func,
+  refetch: PropTypes.func,
+};
+
+FriendModal.defaultProps = {
+  modalContent: null,
+  dispatchModalContent: null,
+  refetch: null,
+};
+
+export default function FriendModal({
+  modalContent,
+  dispatchModalContent,
+  refetch,
+}) {
+  const [deleteFriendRequest] = useMutation(DELETE_FRIEND, {
+    onCompleted(result) {
+      dispatchModalContent({
+        type: 'deleteDone',
+        nickname: result.deleteFriend.nickname,
+      });
+      refetch();
+    },
+    onError() {
+      dispatchModalContent({
+        type: 'error',
+        content: '에러가 발생했습니다.',
+      });
+    },
+  });
+  const [sendFriendRequest] = useMutation(SEND_FRIEND_REQUEST, {
+    onCompleted(result) {
+      dispatchModalContent({
+        type: 'addDone',
+        nickname: result.sendFriendRequest.nickname,
+      });
+    },
+    onError({ graphQLErrors }) {
+      dispatchModalContent({
+        type: 'error',
+        content: graphQLErrors[0].message,
+      });
+    },
+  });
+
+  function clearModalContent() {
+    dispatchModalContent({ type: 'clear' });
+  }
+
+  function clickOKButton() {
+    switch (modalContent.current) {
+      case 'addDone':
+      case 'deleteDone':
+      case 'error':
+        return dispatchModalContent({ type: 'clear' });
+      case 'addRequest':
+        return sendFriendRequest({
+          variables: { nickname: modalContent.nickname },
+        });
+      case 'deleteRequest':
+        return deleteFriendRequest({
+          variables: { nickname: modalContent.nickname },
+        });
+      default:
+        throw new Error(`${modalContent.current}cannot find current`);
+    }
+  }
+
+  const Body = () => <span>{modalContent.content}</span>;
+  const Footer = () => (
+    <ButtonSection>
+      <Button onClick={clickOKButton}>확인</Button>
+      <Button onClick={clearModalContent}>취소</Button>
+    </ButtonSection>
+  );
+
+  const Modal = makeModal(null, Body, Footer);
+
+  return <>{modalContent.content ? <Modal /> : null}</>;
+}

--- a/front-end/FriendsSection/FriendList/FriendModal/FriendModal.style.js
+++ b/front-end/FriendsSection/FriendList/FriendModal/FriendModal.style.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const ButtonSection = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 9rem;
+`;

--- a/front-end/FriendsSection/FriendList/Header/Header.js
+++ b/front-end/FriendsSection/FriendList/Header/Header.js
@@ -1,0 +1,66 @@
+import React, { useState, useCallback } from 'react';
+import { faCog, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  DoneButton,
+  Input,
+} from 'components/FriendsSection/refactor/FriendList/Header/Header.style';
+import {
+  ComponentStyle,
+  Icon,
+} from 'components/FriendsSection/refactor/FriendList/Component/Component.style';
+import regex from 'constant/TextInput';
+import PropTypes from 'prop-types';
+
+Header.propTypes = {
+  isConfigMode: PropTypes.bool,
+  switchMode: PropTypes.func,
+  dispatchModalContent: PropTypes.func,
+};
+
+Header.defaultProps = {
+  isConfigMode: false,
+  switchMode: null,
+  dispatchModalContent: null,
+};
+
+export default function Header({
+  isConfigMode,
+  switchMode,
+  dispatchModalContent,
+}) {
+  const [inputValue, setValue] = useState('');
+
+  const inputChangeHandler = useCallback(
+    (e) => {
+      if (regex.test(e.target.value)) {
+        setValue(e.target.value);
+      }
+    },
+    [setValue],
+  );
+
+  function addFriend() {
+    dispatchModalContent({ type: 'addRequest', nickname: inputValue });
+  }
+
+  return (
+    <>
+      {isConfigMode ? (
+        <>
+          <ComponentStyle>
+            <DoneButton onClick={switchMode}>완료</DoneButton>
+          </ComponentStyle>
+          <ComponentStyle>
+            <Input onChange={inputChangeHandler} value={inputValue} />
+            <Icon icon={faUserPlus} onClick={addFriend} />
+          </ComponentStyle>
+        </>
+      ) : (
+        <ComponentStyle>
+          <span>친구 목록</span>
+          <Icon icon={faCog} onClick={switchMode} />
+        </ComponentStyle>
+      )}
+    </>
+  );
+}

--- a/front-end/FriendsSection/FriendList/Header/Header.style.js
+++ b/front-end/FriendsSection/FriendList/Header/Header.style.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import ButtonStyle from 'components/globalComponents/Button/Button.style';
+
+export const DoneButton = styled(ButtonStyle)`
+  width: 3rem;
+  height: 1.5rem;
+  margin-left: auto;
+  margin-right: 0;
+  border: 1px solid white;
+`;
+
+export const Input = styled.input.attrs(() => ({
+  type: 'text',
+  placeholder: '친구 닉네임..',
+}))`
+  width: 5rem;
+  height: 1.3rem;
+  margin-right: 0.4rem;
+  margin-left: -0.5rem;
+  border-radius: 1rem;
+  border: 0;
+`;

--- a/front-end/FriendsSection/FriendList/modalReducer.js
+++ b/front-end/FriendsSection/FriendList/modalReducer.js
@@ -1,0 +1,42 @@
+const modalReducer = (state, action) => {
+  switch (action.type) {
+    case 'clear':
+      return { ...state, content: null };
+    case 'deleteRequest':
+      return {
+        content: `${action.nickname}님을 삭제하시겠습니까?`,
+        nickname: action.nickname,
+        current: 'deleteRequest',
+      };
+    case 'deleteDone':
+      return {
+        ...state,
+        content: `${action.nickname}님이 삭제되었습니다.`,
+        current: 'deleteDone',
+      };
+    case 'addRequest':
+      if (!action.nickname)
+        return { ...state, content: '친구의 닉네임을 입력해주세요' };
+      return {
+        content: `${action.nickname}님을 추가하시겠습니까?`,
+        nickname: action.nickname,
+        current: 'addRequest',
+      };
+    case 'addDone':
+      return {
+        ...state,
+        content: `${action.nickname}님에게 요청이 전달되었습니다.`,
+        current: 'addDone',
+      };
+    case 'error':
+      return {
+        ...state,
+        content: action.content,
+        current: 'error',
+      };
+    default:
+      throw new Error(`${action.type} is wrong action type`);
+  }
+};
+
+export default modalReducer;

--- a/front-end/FriendsSection/FriendsSection.context.js
+++ b/front-end/FriendsSection/FriendsSection.context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const FriendsSectionContext = React.createContext();
+
+export default FriendsSectionContext;

--- a/front-end/FriendsSection/FriendsSection.js
+++ b/front-end/FriendsSection/FriendsSection.js
@@ -1,0 +1,32 @@
+import React, { useReducer } from 'react';
+import useOnlineFriends from 'hooks/Online/useOnlineFriends';
+import FriendsSectionContext from 'components/FriendsSection/refactor/FriendsSection.context';
+import { ListPopUpButton } from 'components/FriendsSection/refactor/FriendsSection.style';
+import FriendList from 'components/FriendsSection/refactor/FriendList/FriendList';
+
+function switchListOpenReducer(state, action) {
+  return !action.current;
+}
+
+export default function FriendsSection() {
+  const [onlineFriends, onlineFriendsDispatch] = useOnlineFriends();
+  const [listOpen, dispatchListOpen] = useReducer(switchListOpenReducer, false);
+
+  function switchListOpen() {
+    dispatchListOpen({ current: listOpen });
+  }
+
+  return (
+    <FriendsSectionContext.Provider
+      value={{
+        onlineFriends,
+        onlineFriendsDispatch,
+      }}
+    >
+      {listOpen ? <FriendList /> : null}
+      <ListPopUpButton onClick={switchListOpen}>
+        {listOpen ? '목록 숨기기' : '친구 목록'}
+      </ListPopUpButton>
+    </FriendsSectionContext.Provider>
+  );
+}

--- a/front-end/FriendsSection/FriendsSection.style.js
+++ b/front-end/FriendsSection/FriendsSection.style.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import ButtonStyle from 'components/globalComponents/Button/Button.style';
+
+export const ListPopUpButton = styled(ButtonStyle)`
+  position: fixed;
+  bottom: 3rem;
+  right: 2rem;
+  width: 9rem;
+  height: 3.8rem;
+  font-size: 25px;
+`;


### PR DESCRIPTION
http://catchmymind.shop/ 의 오른쪽에 친구목록 기능을 리팩토링했습니다. 바쁘실텐데 시간 내주셔서 감사합니다!

### 동작
- 친구 목록 클릭시 목록이 열리면서 친구들 조회 가능합니다.
- 설정 버튼을 누르면 친구 요청을 보낼 수 있고, 친구 삭제를 할 수 있어집니다.
- 친구 삭제 및 요청을 누르면 모달이 뜨면서 '진행하시겠습니까?'를 한번더 물어봅니다.
- 모달에서 확인을 누르면 '진행 완료되었습니다. / 이미 친구요청을 보냈습니다. / 없는 유저입니다. / 에러가 발생했습니다. ' 라는 알림이 뜹니다.
- 받은 친구 요청은 상단의 네비게이션 바의 알림칸에서 확인 가능합니다. (코드리뷰에 포함하지 않았습니다.)

### back의 graphQL query문 목록들
- friends : 친구목록 조회
- findFriendRequests : 받은 친구요청 목록 조회
- deleteFriend : 친구를 목록에서 삭제
- deleteFriendRequest : 받은 친구요청 삭제
- acceptFriendRequest : 친구 요청 수락
- sendFriendRequest : 친구 요청 보내기



### front의 컴포넌트들
- friendsSection (가장 최상단)
  - ListPopUpButton (FriendList가 열렸다 닫혔다 하는 스위치)
  - FriendList (isConfigMode를 통해서 true일 때 친구 추가/삭제 가능, false일 때 친구 목록 조회)
    - Header (isConfigMode일 때 친구 추가를 할 수 있는 섹션. input과 친구 요청 버튼이 있음)
    - Component (친구 하나. FriendList에서 map으로 불러옴. 삭제 버튼이 있음)
    - FriendModal (친구 요청/삭제 버튼을 누르면 진행할 건지 물어보는 모달을 띄워줌. 모달에서 확인을 눌러야 진짜로 삭제, 요청이 이루어짐)


### front props
FriendList에서 밑의 컴포넌트들에게 isConfigMode, disPatchModalContent를 내려줍니다.
실제로 백에 친구의 추가/요청을 전달하는 것은 이 disPatchModalContent로
모달에서 '확인'을 눌렀을 때 작업이 일어난 후 다시 refetch를 통해 친구 목록을 불러옵니다.


### 궁금한 사항들
- 리팩토링했지만 이 구조가 효율적인 구조인지 확신이 안섭니다.
- modalReducer를 사용하는 부분에서 고칠 부분이 있는지 궁금합니다.

+a) 이건 여담인데 string변수를 만들어서 height가 auto인 div안에서 변수 내용을 화면에 띄우고자 했습니다. 이 때, 변수값이 없어도 자리는 차지하게 하고 싶었지만 null로 주면 그 자리가 없어지더라고요.... 혹시 useState로 공백을 변수안에 넣는 방법이 있을까요? useState('&nbsp ;');이런식으로 하고싶은데 잘 안되네요ㅠ